### PR TITLE
Removed deprecated cocoapods support in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,3 @@ https://github.com/Paytm-Payments/Paytm_App_Checksum_Kit_DotNet
 
 # Transaction Status API
 http://paywithpaytm.com/developer/paytm_api_doc?target=txn-status-api
-
-# Steps to configure via PODS
-1. Pod init in the project Directory. It will create a Podfile.
-2. Add source 'https://github.com/Paytm-Payments/Paytm_iOS_App_Kit.git' source 'https://github.com/CocoaPods/Specs.git' at the top of the podfile
-3. Add pod 'Paytm-Payments' in the pod file.
-4. Save and run pod install in the terminal
-5. Open xcorkspace
-6. Go to App Target -> Build Phases -> Link Binaries with libraries and add **SystemConfiguaration.framework**
-7. Go to Pods Target -> Build Phases -> Link Binaries with libraries and add drag libPaymentsSDK.a there From Pods Resources


### PR DESCRIPTION
Updated readme as cocoapods support is now deprecated. user should integrate the sdk using either swift framework or objc library.